### PR TITLE
Removal of ZMQ and including Python keypoint provider

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -9,7 +9,6 @@ cc_binary(
     deps = [
         "//gestop:hand_tracking_landmarks",
         "//mediapipe/graphs/hand_tracking:mobile_calculators",
-        ":zeromq",
     ],
 )
 
@@ -18,7 +17,6 @@ cc_binary(
     deps = [
         "//gestop:hand_tracking_landmarks_cpu",
         "//mediapipe/graphs/hand_tracking:desktop_tflite_calculators",
-        ":zeromq",
     ],
 )
 
@@ -32,26 +30,6 @@ proto_library(
     srcs = ["proto/landmarkList.proto"],
 )
 
-
-cc_import(
-    name = "zeromq",
-    hdrs = ["zmq.hpp"],
-    shared_library = "libzmq.so",
-)
-
-#cc_library(
-#    name = "zeromq",
-#    #hdrs = ["zmq.hpp"],
-#    hdrs = glob(["*.hpp"]),
-#    visibility = ["//visibility:public"],
-#    srcs = ["libzmq.so"]
-
-#    includes = ["zmq.hpp"],
-#    #shared_library = "libzmq.so",
-#    srcs = [ 
-#        "cppzmq/zmq.hpp",
-#        "libzmq.so"],
-#)
 
 # Linux only.
 # Must have a GPU with EGL support:

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ python gestop/hand_tracking.py
 
 ##### MediaPipe C++ API
 
-1. Clone mediapipe and set it up. Make sure the provided hand tracking example is working.
-2. Clone this repo in the top level directory of mediapipe. Install all dependencies.
+1. Download mediapipe and set it up. MediaPipe >=0.8.0 is **NOT** supported and should no be used. Make sure the provided hand tracking example is working to verify if all dependencies are installed.
+2. Clone this repo in the top level directory of mediapipe. Install all of Gestop's dependencies.
 3. Run the instructions below to build and then execute the code. 
 
 *Note:* Run build instructions in the `mediapipe/` directory, not inside this directory.

--- a/README.md
+++ b/README.md
@@ -19,10 +19,7 @@ In addition, it is possible to extend and customize the functionality of the app
 
 ### Requirements
 
-As well as mediapipe's own requirements, there are a few other libraries required for this project.
-
-* **ZeroMQ** - The zeromq library (*libzmq.so*) must be installed and symlinked into this directory. The header only C++ binding **cppzmq** must also be installed and its header (*zmq.hpp*) symlinked into the directory. 
-* **pyzmq**
+* **opencv**
 * **protobuf** 
 * **pynput**
 * **pytorch**
@@ -31,40 +28,57 @@ As well as mediapipe's own requirements, there are a few other libraries require
 
 ### Usage
 
-1. Clone mediapipe and set it up. Make sure the provided hand tracking example is working.
-2. Clone this repo in the top level directory of mediapipe. Install all dependencies.
-3. Download the `models/` folder from the link above and place it in the `gestop/` directory.
-4. Run the instructions below to build and then execute the code. 
+#### Server
 
-*Note:* Run build instructions in the `mediapipe/` directory, not inside this directory.
+To start the **Gestop** server, do the following:
+
+1. Clone this repo and install all its dependencies.
+2. Download the `models/` folder from the link above and place it in the `gestop/` directory.
+3. Start the server with the following command:
+
+``` python
+python gestop/gesture_receiver.py
+```
 
 *Note:* Python dependencies can be installed simply by creating a virtual environment and running `pip install -r requirements.txt`
 
-#### Mediapipe Executable
+#### Client
 
-##### GPU (Linux only)
+The client, or the *keypoint provider*, can be setup either through MediaPipe's C++ API, or through its Python API. The Python API is simpler to setup and is recommended.
+
+#### MediaPipe Python API
+
+Install the libraries required by `hand_tracking.py` i.e. **opencv** and **mediapipe**. Then, run the code with:
+
+``` python
+python gestop/hand_tracking.py
+```
+
+##### MediaPipe C++ API
+
+1. Clone mediapipe and set it up. Make sure the provided hand tracking example is working.
+2. Clone this repo in the top level directory of mediapipe. Install all dependencies.
+3. Run the instructions below to build and then execute the code. 
+
+*Note:* Run build instructions in the `mediapipe/` directory, not inside this directory.
+
+###### GPU (Linux only)
 ``` sh
 bazel build -c opt --verbose_failures --copt -DMESA_EGL_NO_X11_HEADERS --copt -DEGL_NO_X11 gestop:hand_tracking_gpu
 
 GLOG_logtostderr=1 bazel-bin/gestop/hand_tracking_gpu --calculator_graph_config_file=gestop/hand_tracking_desktop_live.pbtxt
 ```
 
-##### CPU
+###### CPU
 ``` sh
 bazel build -c opt --define MEDIAPIPE_DISABLE_GPU=1 gestop:hand_tracking_cpu
 
 GLOG_logtostderr=1 bazel-bin/gestop/hand_tracking_cpu --calculator_graph_config_file=gestop/hand_tracking_desktop_live.pbtxt
 ```
 
-#### Python Script
-
-``` python
-python gestop/gesture_receiver.py
-```
-
 ### Overview
 
-The hand keypoints are detected using google's mediapipe. These keypoints are then fed into `gesture_receiver.py` through zmq. The tool recognizes two kinds of gestures:
+The hand keypoints are detected using google's mediapipe. These keypoints are then fed into `gesture_receiver.py` through a socket. The tool recognizes two kinds of gestures:
 
 1. Static Gestures : Gestures whose meaning can be inferred from a single image itself.
 2. Dynamic Gestures : Gestures which can only be understood through a sequence of images i.e. a video.
@@ -75,8 +89,8 @@ For more complicated gestures involving the movement of the hand, dynamic gestur
 
 The project consists of a few distinct pieces which are:
 
-* mediapipe executable - A modified version of the hand tracking example given in mediapipe, this executable tracks the keypoints, stores them in a protobuf, and transmits them using ZMQ.
-* Gesture Receiver - See `gesture_receiver.py`, responsible for handling the ZMQ stream and utilizing the following modules.
+* mediapipe executable - A modified version of the hand tracking example given in mediapipe, this executable tracks the keypoints, stores them in a protobuf, and transmits them using sockets.
+* Gesture Receiver - See `gesture_receiver.py`, responsible for handling the stream and utilizing the following modules.
 * Mouse Tracker - See `mouse_tracker.py`, responsible for moving the cursor using the position of the index finger.
 * Gesture Recognizer - See `gesture_recognizer.py`, takes in the keypoints from the mediapipe executable, and converts them into a high level description of the state of the hand, i.e. a gesture name.
 * Gesture Executor - See `gesture_executor.py`, uses the gesture name from the previous module, and executes an action.

--- a/config.py
+++ b/config.py
@@ -40,15 +40,15 @@ class Config:
     else:
         map_location = None
 
-    if not os.path.exists('logs'):
-        os.mkdir('logs')
+    if not os.path.exists('gestop/logs'):
+        os.mkdir('gestop/logs')
 
     # Set up logger
     logging.basicConfig(
         level=logging.DEBUG,
         format="%(asctime)s [%(levelname)s] %(message)s",
         handlers=[
-            logging.FileHandler("logs/debug{}.log".format(
+            logging.FileHandler("gestop/logs/debug{}.log".format(
                 datetime.datetime.now().strftime("%m.%d:%H.%M.%S"))),
             logging.StreamHandler(stdout)
         ]

--- a/gesture_receiver.py
+++ b/gesture_receiver.py
@@ -8,7 +8,7 @@ from functools import partial
 import argparse
 import logging
 
-import zmq
+import socket
 from pynput.keyboard import Listener, Key
 
 from proto import landmarkList_pb2
@@ -112,25 +112,31 @@ def process_data(data, landmark_list, C, S):
 
     S = handle_and_recognize(landmarks, handedness, C, S)
 
-def handle_zmq_stream(args):
+def handle_stream(args):
     ''' Handles the incoming stream of data from mediapipe. '''
 
     C, S, landmark_list = all_init(args)
 
-    # setup zmq context
-    context = zmq.Context()
-    sock = context.socket(zmq.PULL)
-    sock.connect("tcp://127.0.0.1:5556")
+    # setup socket
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 
+    HOST = '127.0.0.1'
+    PORT = 5556
+    sock.bind((HOST, PORT))
+    sock.listen(1)
+
+    conn, addr = sock.accept()
     # Main while loop
     while True:
-        data = sock.recv()
+        data = conn.recv(4096)
         process_data(data, landmark_list, C, S)
 
         # The key listener thread has shut down, leaving only MainThread
         if threading.active_count() == 1:
             break
 
+    conn.close()
+    sock.close()
 
 if __name__ == "__main__":
     # run_socket_server()
@@ -151,5 +157,5 @@ if __name__ == "__main__":
                         dest="exec_action", action='store_false')
     args = parser.parse_args()
 
-    handle_zmq_stream(args)
+    handle_stream(args)
     logging.info("Shutdown successfully")

--- a/hand_tracking.py
+++ b/hand_tracking.py
@@ -1,0 +1,64 @@
+import cv2
+import mediapipe as mp
+import socket
+
+from proto import landmarkList_pb2
+
+mp_drawing = mp.solutions.drawing_utils
+mp_hands = mp.solutions.hands
+
+sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+HOST = '127.0.0.1'
+PORT = 5556
+try:
+  sock.connect((HOST, PORT))
+except:
+  print("Server Connection Failed")
+  exit(0)
+
+# For webcam input:
+hands = mp_hands.Hands(
+    min_detection_confidence=0.7, min_tracking_confidence=0.5)
+cap = cv2.VideoCapture(0)
+while cap.isOpened():
+  success, image = cap.read()
+  if not success:
+    break
+
+  # Flip the image horizontally for a later selfie-view display, and convert
+  # the BGR image to RGB.
+  image = cv2.cvtColor(cv2.flip(image, 1), cv2.COLOR_BGR2RGB)
+  # To improve performance, optionally mark the image as not writeable to
+  # pass by reference.
+  image.flags.writeable = False
+  results = hands.process(image)
+
+  landmarkList = landmarkList_pb2.LandmarkList()
+
+  # Draw the hand annotations on the image.
+  image.flags.writeable = True
+  image = cv2.cvtColor(image, cv2.COLOR_RGB2BGR)
+  if results.multi_hand_landmarks:
+    hand_landmarks = results.multi_hand_landmarks[0]
+    handedness = results.multi_handedness[0].classification[0].index
+
+    landmarkList.handedness = handedness
+    for lmark in hand_landmarks.landmark:
+      l = landmarkList.landmark.add()
+      l.x = lmark.x
+      l.y = lmark.y
+      l.z = lmark.z*256
+
+    output = landmarkList.SerializeToString()
+    sock.send(output)
+
+    mp_drawing.draw_landmarks(
+          image, hand_landmarks, mp_hands.HAND_CONNECTIONS)
+
+  cv2.imshow('MediaPipe Hands', image)
+  if cv2.waitKey(5) & 0xFF == 27:
+    break
+hands.close()
+cap.release()
+sock.close()

--- a/static_train_model.py
+++ b/static_train_model.py
@@ -107,7 +107,7 @@ def main():
     ##################
 
     # Read and format the csv
-    df = pd.read_csv("data/static_gestures_data.csv")
+    df = pd.read_csv("gestop/data/static_gestures_data.csv")
     train, test = train_test_split(df, test_size=0.1, random_state=C.seed_val)
     train_X, train_Y = split_dataframe(train)
     test_X, test_Y = split_dataframe(test)
@@ -122,7 +122,7 @@ def main():
     # Store encoding to disk
     le_name_mapping = dict(zip([int(i) for i in le.transform(le.classes_)], le.classes_))
     logging.info(le_name_mapping)
-    with open('data/static_gesture_mapping.json', 'w') as f:
+    with open('gestop/data/static_gesture_mapping.json', 'w') as f:
         f.write(json.dumps(le_name_mapping))
 
 


### PR DESCRIPTION
ZMQ has been removed as a dependency and replaced with plain sockets. The MediaPipe Python API now supports hand tracking and a python keypoint provider has been added. The README has been updated to reflect these changes